### PR TITLE
WIP: `Parser`: option `lazyFunctionBodyParsing`

### DIFF
--- a/pkg/analyzer/lib/dart/analysis/utilities.dart
+++ b/pkg/analyzer/lib/dart/analysis/utilities.dart
@@ -46,6 +46,7 @@ ParseStringResult parseFile({
   ResourceProvider? resourceProvider,
   required FeatureSet featureSet,
   bool throwIfDiagnostics = true,
+  bool lazyFunctionBodyParsing = false,
 }) {
   resourceProvider ??= PhysicalResourceProvider.INSTANCE;
   var content = (resourceProvider.getResource(path) as File).readAsStringSync();
@@ -54,6 +55,7 @@ ParseStringResult parseFile({
     path: path,
     featureSet: featureSet,
     throwIfDiagnostics: throwIfDiagnostics,
+    lazyFunctionBodyParsing: lazyFunctionBodyParsing,
   );
 }
 
@@ -79,6 +81,7 @@ ParseStringResult parseString({
   FeatureSet? featureSet,
   String? path,
   bool throwIfDiagnostics = true,
+  bool lazyFunctionBodyParsing = false,
 }) {
   featureSet ??= FeatureSet.latestLanguageVersion();
   var source = StringSource(content, path ?? '');
@@ -100,6 +103,7 @@ ParseStringResult parseString({
     featureSet: scanner.featureSet,
     languageVersion: languageVersion,
     lineInfo: lineInfo,
+    lazyFunctionBodyParsing: lazyFunctionBodyParsing,
   );
   var unit = parser.parseCompilationUnit(token);
   ParseStringResult result = ParseStringResultImpl(

--- a/pkg/analyzer/lib/src/generated/parser.dart
+++ b/pkg/analyzer/lib/src/generated/parser.dart
@@ -35,6 +35,7 @@ class Parser {
     bool allowNativeClause = true,
     required LibraryLanguageVersion languageVersion,
     required LineInfo lineInfo,
+    bool lazyFunctionBodyParsing = false,
   }) : astBuilder = AstBuilder(
          ErrorReporter(errorListener, source),
          source.uri,
@@ -47,6 +48,7 @@ class Parser {
       astBuilder,
       allowPatterns: featureSet.isEnabled(Feature.patterns),
       enableFeatureEnhancedParts: featureSet.isEnabled(Feature.enhanced_parts),
+      lazyFunctionBodyParsing: lazyFunctionBodyParsing,
     );
     astBuilder.parser = fastaParser;
     astBuilder.allowNativeClause = allowNativeClause;


### PR DESCRIPTION
`Parser`:

- Added option `lazyFunctionBodyParsing`.

Enables fast function body parsing by skipping statement details: useful when only the function signature or outer structure is needed, such as during metadata collection, outlining, indexing, or code generation.

---

- [ ✅] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
